### PR TITLE
UTF-8 encoding used for output string

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,10 @@ type = custom/script
 interval = 1
 format-prefix = " "
 format = <label>
-exec = /path/to/spotify/script
+exec = python /path/to/spotify/script -t 42
 
 format-underline = #1db954
+~~~
+
+The argument "-t" is optional and sets the `trunlen`. 
+ 

--- a/spotify_status.py
+++ b/spotify_status.py
@@ -31,4 +31,4 @@ try:
     output = artist + ': ' + song
     print(output.encode('utf-8'))
 except Exception as e:
-    print(e)
+    print("")

--- a/spotify_status.py
+++ b/spotify_status.py
@@ -1,9 +1,17 @@
 #!/bin/python
 
 import dbus
+import argparse
 
-trunclen = 25
 
+parser = argparse.ArgumentParser()
+parser.add_argument('-t', '--trunclen', type=int, metavar='trunclen')
+args = parser.parse_args()
+
+if hasattr(args, 'trunclen'):
+    trunclen = args.trunclen
+else:
+    trunclen = 25
 try:
     session_bus = dbus.SessionBus()
     spotify_bus = session_bus.get_object("org.mpris.MediaPlayer2.spotify", "/org/mpris/MediaPlayer2")
@@ -20,8 +28,7 @@ try:
         song += '...' 
         if ('(' in song) and (')' not in song):
             song += ')'
-
     output = artist + ': ' + song
-    print(output)
-except:
-    print("")
+    print(output.encode('utf-8'))
+except Exception as e:
+    print(e)


### PR DESCRIPTION
- added UTF-8 encoding to prevent encoding errors for track/artist names with non ascii characters.
- script parameter for `trunlen` 
-  updated README 