### PR TITLE
python2 and python3 compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This is a module that shows the current song playing and its primary artist on Spotify, with a Spotify-green underline, for people that don't want to set up mpd. If Spotify is not active, nothing is shown. If the song name is longer than `trunclen` characers (default 25), it is truncated and `...` is appended. If the song is truncated and contains a single opening parenthesis, the closing paranethsis is appended as well.
 
-This module requires python 3.x and the `dbus` module.
+This module requires python an the `dbus` module.
 
 [![sample screenshot](https://i.imgur.com/kEluTSq.png)](https://i.imgur.com/kEluTSq.png)
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 This is a module that shows the current song playing and its primary artist on Spotify, with a Spotify-green underline, for people that don't want to set up mpd. If Spotify is not active, nothing is shown. If the song name is longer than `trunclen` characers (default 25), it is truncated and `...` is appended. If the song is truncated and contains a single opening parenthesis, the closing paranethsis is appended as well.
 
-This module requires python an the `dbus` module.
+### Dependencies
+- Python (2.x or 3.x)
+- Python `dbus` module
 
 [![sample screenshot](https://i.imgur.com/kEluTSq.png)](https://i.imgur.com/kEluTSq.png)
 

--- a/spotify_status.py
+++ b/spotify_status.py
@@ -1,5 +1,6 @@
 #!/bin/python
 
+import sys
 import dbus
 import argparse
 
@@ -30,7 +31,12 @@ try:
         if ('(' in song) and (')' not in song):
             song += ')'
     output = artist + ': ' + song
-    print(output.encode('utf-8'))
+    
+    # Python3 uses UTF-8 by default. 
+    if sys.version_info.major == 3:
+        print(output)
+    else:
+        print(output.encode('UTF-8'))
 except Exception as e:
     if isinstance(e, dbus.exceptions.DBusException):
         print("")


### PR DESCRIPTION
If python3 is the system default, then all strings are already UTF-8 encoded. 
The python3 encode method prepends `b'` to the string. 