### PR TITLE
Make script more portable

### DIFF
--- a/spotify_status.py
+++ b/spotify_status.py
@@ -1,4 +1,4 @@
-#!/bin/python
+#!/usr/bin/env python
 
 import sys
 import dbus


### PR DESCRIPTION
Ubuntu 20.04 doesn't install python at /bin/python anymore.
It is more portable to usr /usr/bin/env which is available in all modern distros.
As a side effect, this also makes the script compatible with virtualenv.